### PR TITLE
Add a device orientation driver

### DIFF
--- a/driver/deviceOrientation.js
+++ b/driver/deviceOrientation.js
@@ -1,20 +1,24 @@
 (function () {
-    var onDeviceAdded = function (deviceAddedCallback, options) {
-        var device = {
-            ID: "browserDeviceOrientation",
-            sensors: {
-                orientation: {
-                    subscribe: function (handler) {
-                        window.addEventListener("deviceorientation", handler, false);
-                    }
+    var device = {
+        ID: "BrowserDeviceOrientation",
+        sensors: {
+            orientation: {
+                subscribe: function (handler) {
+                    window.addEventListener("deviceorientation", handler, false);
+                },
+                unsubscribe: function (handler) {
+                    window.removeEventListener("deviceorientation", handler, false);
                 }
             }
-        };
+        }
+    };
+
+    var onDeviceAdded = function (deviceAddedCallback) {
         deviceAddedCallback(device);
     };
 
-    var onDeviceRemoved = function () {
-        // TODO
+    var onDeviceRemoved = function (deviceRemovedCallback) {
+        deviceRemovedCallback(device);
     };
 
     return {

--- a/driver/deviceOrientation.js
+++ b/driver/deviceOrientation.js
@@ -1,0 +1,24 @@
+(function () {
+    var onDeviceAdded = function (deviceAddedCallback, options) {
+        var device = {
+            ID: "browserDeviceOrientation",
+            sensors: {
+                orientation: {
+                    subscribe: function (handler) {
+                        window.addEventListener("deviceorientation", handler, false);
+                    }
+                }
+            }
+        };
+        deviceAddedCallback(device);
+    };
+
+    var onDeviceRemoved = function () {
+        // TODO
+    };
+
+    return {
+        onDeviceAdded: onDeviceAdded,
+        onDeviceRemoved: onDeviceRemoved
+    };
+}());

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "sensorapijs",
+    "version": "1.0.0",
+    "license": "Apache",
+    "author": "Anton Truong <truong@teco.edu>",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/teco-kit/p4a-sensorAPI.git"
+    }
+}


### PR DESCRIPTION
A little while ago I made a simple device orientation driver for p4a-sensorAPI that I would like to give to the project.

If you would be open to including it, please take a look at the pull request and let me know how it looks and what other work would be needed to make it suitable for adding to p4a-sensorAPI.

This pull request also includes a package.json for use with NPM. Please let me know what you think about including that. I'm using p4a-sensorAPI via NPM in this project: https://github.com/simonbates/nexus-demos/blob/master/package.json
